### PR TITLE
Get documents and low confidence flag

### DIFF
--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -1,14 +1,24 @@
 from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File, Query
 from sqlalchemy.orm import Session
 from sqlalchemy import func
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
+from uuid import UUID
 import logging
 import math
 
 from ..db import get_db
 from ..auth import get_current_user
-from ..models import User, Document
-from ..schemas.document import DocumentUploadResponse, DocumentUploadResult, DocumentListResponse, DocumentResponse, PaginationMeta
+from ..models import User, Document, ExtractedField, LineItem
+from ..schemas.document import (
+    DocumentUploadResponse, 
+    DocumentUploadResult, 
+    DocumentListResponse, 
+    DocumentResponse, 
+    PaginationMeta,
+    DocumentFieldsResponse,
+    ExtractedFieldResponse,
+    LineItemResponse
+)
 from ..services.blob import get_azure_blob_service
 from ..enums import FileType, DocumentType, DocumentStatus
 from ..tasks.ocr import dispatch_ocr_task
@@ -284,4 +294,194 @@ async def list_business_documents(
     return DocumentListResponse(
         documents=document_responses,
         pagination=pagination
+    )
+
+
+def calculate_fields_summary(fields: List[ExtractedField]) -> Dict[str, Any]:
+    """Calculate summary statistics for extracted fields"""
+    if not fields:
+        return {
+            "total_fields": 0,
+            "fields_with_values": 0,
+            "fields_without_values": 0,
+            "average_confidence": 0.0,
+            "high_confidence_fields": 0,
+            "medium_confidence_fields": 0,
+            "low_confidence_fields": 0
+        }
+    
+    total_fields = len(fields)
+    fields_with_values = len([f for f in fields if f.value is not None and f.value.strip() != ""])
+    
+    confidences = [f.confidence for f in fields if f.confidence is not None and f.value is not None and f.value.strip() != ""]
+    average_confidence = sum(confidences) / len(confidences) if confidences else 0.0
+    
+    high_confidence = len([c for c in confidences if c >= 0.8])
+    medium_confidence = len([c for c in confidences if 0.5 <= c < 0.8])
+    low_confidence = len([c for c in confidences if c < 0.5])
+    
+    # Count fields that are flagged as low confidence (< 0.7 or None)
+    flagged_low_confidence = len([f for f in fields if is_low_confidence(f.confidence)])
+    
+    return {
+        "total_fields": total_fields,
+        "fields_with_values": fields_with_values,
+        "fields_without_values": total_fields - fields_with_values,
+        "average_confidence": round(average_confidence, 3),
+        "high_confidence_fields": high_confidence,
+        "medium_confidence_fields": medium_confidence,
+        "low_confidence_fields": low_confidence,
+        "flagged_low_confidence_fields": flagged_low_confidence
+    }
+
+
+def is_low_confidence(confidence: Optional[float]) -> bool:
+    """
+    Determine if a confidence score indicates low confidence.
+    
+    Args:
+        confidence: Confidence score (0.0 to 1.0) or None
+        
+    Returns:
+        True if confidence < 0.7 or confidence is None
+    """
+    if confidence is None:
+        return True
+    return confidence < 0.7
+
+
+def calculate_line_items_summary(line_items: List[LineItem]) -> Dict[str, Any]:
+    """Calculate summary statistics for line items"""
+    if not line_items:
+        return {
+            "total_line_items": 0,
+            "items_with_descriptions": 0,
+            "items_with_totals": 0,
+            "average_confidence": 0.0,
+            "total_amount": 0.0
+        }
+    
+    total_line_items = len(line_items)
+    items_with_descriptions = len([item for item in line_items if item.description is not None and item.description.strip() != ""])
+    items_with_totals = len([item for item in line_items if item.total is not None])
+    
+    confidences = [item.confidence for item in line_items if item.confidence is not None]
+    average_confidence = sum(confidences) / len(confidences) if confidences else 0.0
+    
+    total_amount = sum([float(item.total) for item in line_items if item.total is not None])
+    
+    # Count line items that are flagged as low confidence (< 0.7 or None)
+    flagged_low_confidence = len([item for item in line_items if is_low_confidence(item.confidence)])
+    
+    return {
+        "total_line_items": total_line_items,
+        "items_with_descriptions": items_with_descriptions,
+        "items_with_totals": items_with_totals,
+        "average_confidence": round(average_confidence, 3),
+        "total_amount": round(total_amount, 2),
+        "flagged_low_confidence_items": flagged_low_confidence
+    }
+
+
+@router.get("/{document_id}/fields", response_model=DocumentFieldsResponse)
+async def get_document_fields(
+    document_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Get all extracted fields and line items for a specific document.
+    
+    Returns:
+    - Document information (status, type, confidence)
+    - All extracted fields with confidence scores
+    - All line items with details
+    - Summary statistics for fields and line items
+    
+    Works for both completed and pending document states:
+    - PENDING/PROCESSING: Returns empty fields/line items with status info
+    - COMPLETED: Returns full extraction results
+    - FAILED: Returns error status with empty results
+    """
+    # Get the document and verify ownership
+    document = db.query(Document).filter(
+        Document.id == document_id,
+        Document.business_id == current_user.business_id
+    ).first()
+    
+    if not document:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Document not found or access denied"
+        )
+    
+    # Get extracted fields for this document
+    extracted_fields = db.query(ExtractedField).filter(
+        ExtractedField.document_id == document_id
+    ).order_by(ExtractedField.field_name).all()
+    
+    # Get line items for this document
+    line_items = db.query(LineItem).filter(
+        LineItem.document_id == document_id
+    ).order_by(LineItem.id).all()
+    
+    # Convert to response format
+    field_responses = [
+        ExtractedFieldResponse(
+            id=field.id,
+            field_name=field.field_name,
+            value=field.value,
+            confidence=field.confidence,
+            is_low_confidence=is_low_confidence(field.confidence),
+            created_at=field.created_at,
+            updated_at=field.updated_at
+        )
+        for field in extracted_fields
+    ]
+    
+    line_item_responses = [
+        LineItemResponse(
+            id=item.id,
+            description=item.description,
+            quantity=float(item.quantity) if item.quantity else None,
+            unit_price=float(item.unit_price) if item.unit_price else None,
+            total=float(item.total) if item.total else None,
+            confidence=item.confidence,
+            is_low_confidence=is_low_confidence(item.confidence),
+            created_at=item.created_at,
+            updated_at=item.updated_at
+        )
+        for item in line_items
+    ]
+    
+    # Create document info response
+    document_info = DocumentResponse(
+        id=document.id,
+        filename=document.filename,
+        file_type=document.file_type,
+        document_type=document.document_type,
+        status=document.status,
+        user_id=document.user_id,
+        business_id=document.business_id,
+        file_url=document.file_url,
+        confidence_score=document.confidence_score,
+        created_at=document.created_at,
+        updated_at=document.updated_at
+    )
+    
+    # Calculate summary statistics
+    fields_summary = calculate_fields_summary(extracted_fields)
+    line_items_summary = calculate_line_items_summary(line_items)
+    
+    logger.info(f"Retrieved {len(extracted_fields)} fields and {len(line_items)} line items for document {document_id}")
+    
+    return DocumentFieldsResponse(
+        document_id=document_id,
+        document_info=document_info,
+        extracted_fields=field_responses,
+        line_items=line_item_responses,
+        processing_status=document.status,
+        overall_confidence=document.confidence_score,
+        fields_summary=fields_summary,
+        line_items_summary=line_items_summary
     )

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -74,3 +74,45 @@ class DocumentListResponse(BaseModel):
     """Paginated response for document listing"""
     documents: List[DocumentResponse]
     pagination: PaginationMeta
+
+
+class ExtractedFieldResponse(BaseModel):
+    """Response schema for extracted fields"""
+    id: int
+    field_name: str
+    value: Optional[str] = None
+    confidence: Optional[float] = None
+    is_low_confidence: bool = Field(description="True if confidence < 0.7")
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+    
+    class Config:
+        from_attributes = True
+
+
+class LineItemResponse(BaseModel):
+    """Response schema for line items"""
+    id: int
+    description: Optional[str] = None
+    quantity: Optional[float] = None
+    unit_price: Optional[float] = None
+    total: Optional[float] = None
+    confidence: Optional[float] = None
+    is_low_confidence: bool = Field(description="True if confidence < 0.7")
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+    
+    class Config:
+        from_attributes = True
+
+
+class DocumentFieldsResponse(BaseModel):
+    """Response schema for document fields endpoint"""
+    document_id: UUID
+    document_info: DocumentResponse
+    extracted_fields: List[ExtractedFieldResponse]
+    line_items: List[LineItemResponse]
+    processing_status: DocumentStatus
+    overall_confidence: Optional[float] = None
+    fields_summary: dict = Field(description="Summary statistics for extracted fields")
+    line_items_summary: dict = Field(description="Summary statistics for line items")

--- a/backend/app/services/field_normalizer.py
+++ b/backend/app/services/field_normalizer.py
@@ -1,0 +1,332 @@
+"""
+Field normalization utilities for mapping Azure Document Intelligence output to internal field keys.
+Handles missing/null values and provides consistent field mappings for invoices and receipts.
+"""
+
+import logging
+from typing import Dict, List, Any, Optional, Union
+from decimal import Decimal, InvalidOperation
+from datetime import datetime, date
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_invoice_fields(azure_fields: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Normalize Azure Document Intelligence invoice fields to internal format.
+    
+    Maps Azure field names to internal keys and handles missing/null values.
+    
+    Args:
+        azure_fields: List of fields from Azure extraction with structure:
+            [{"field_name": str, "value": str, "confidence": float}, ...]
+    
+    Returns:
+        Dictionary with normalized field names and processed values:
+        {
+            "vendor_name": {"value": str, "confidence": float, "raw_value": str},
+            "invoice_date": {"value": date/str, "confidence": float, "raw_value": str},
+            "total_amount": {"value": Decimal, "confidence": float, "raw_value": str},
+            ...
+        }
+    """
+    if not azure_fields or not isinstance(azure_fields, list):
+        logger.warning("Invalid or empty azure_fields provided to normalize_invoice_fields")
+        return {}
+    
+    # Field mapping from Azure Document Intelligence to internal keys
+    field_mappings = {
+        "vendor_name": {"azure_key": "vendor_name", "type": "string"},
+        "vendor_address": {"azure_key": "vendor_address", "type": "string"},
+        "customer_name": {"azure_key": "customer_name", "type": "string"},
+        "customer_address": {"azure_key": "customer_address", "type": "string"},
+        "invoice_number": {"azure_key": "invoice_number", "type": "string"},
+        "invoice_date": {"azure_key": "invoice_date", "type": "date"},
+        "due_date": {"azure_key": "due_date", "type": "date"},
+        "payment_terms": {"azure_key": "payment_terms", "type": "string"},
+        "subtotal": {"azure_key": "subtotal", "type": "decimal"},
+        "tax_amount": {"azure_key": "tax_amount", "type": "decimal"},
+        "total_amount": {"azure_key": "total_amount", "type": "decimal"},
+        "amount_due": {"azure_key": "amount_due", "type": "decimal"},
+        "purchase_order": {"azure_key": "purchase_order", "type": "string"},
+        "billing_address": {"azure_key": "billing_address", "type": "string"},
+        "shipping_address": {"azure_key": "shipping_address", "type": "string"}
+    }
+    
+    # Create lookup dict for faster access
+    azure_field_lookup = {field["field_name"]: field for field in azure_fields}
+    
+    normalized_fields = {}
+    
+    for internal_key, config in field_mappings.items():
+        azure_key = config["azure_key"]
+        field_type = config["type"]
+        
+        # Get the field data from Azure results
+        field_data = azure_field_lookup.get(azure_key)
+        
+        if field_data:
+            raw_value = field_data.get("value", "")
+            confidence = field_data.get("confidence", 0.0)
+            
+            # Normalize the value based on type
+            normalized_value = _normalize_field_value(raw_value, field_type, internal_key)
+            
+            normalized_fields[internal_key] = {
+                "value": normalized_value,
+                "confidence": float(confidence),
+                "raw_value": str(raw_value) if raw_value is not None else "",
+                "field_type": field_type
+            }
+        else:
+            # Handle missing fields
+            normalized_fields[internal_key] = {
+                "value": None,
+                "confidence": 0.0,
+                "raw_value": "",
+                "field_type": field_type
+            }
+    
+    logger.info(f"Normalized {len([f for f in normalized_fields.values() if f['value'] is not None])}/{len(field_mappings)} invoice fields")
+    
+    return normalized_fields
+
+
+def normalize_receipt_fields(azure_fields: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Normalize Azure Document Intelligence receipt fields to internal format.
+    
+    Maps Azure field names to internal keys and handles missing/null values.
+    
+    Args:
+        azure_fields: List of fields from Azure extraction with structure:
+            [{"field_name": str, "value": str, "confidence": float}, ...]
+    
+    Returns:
+        Dictionary with normalized field names and processed values:
+        {
+            "merchant_name": {"value": str, "confidence": float, "raw_value": str},
+            "transaction_date": {"value": date/str, "confidence": float, "raw_value": str},
+            "total_amount": {"value": Decimal, "confidence": float, "raw_value": str},
+            ...
+        }
+    """
+    if not azure_fields or not isinstance(azure_fields, list):
+        logger.warning("Invalid or empty azure_fields provided to normalize_receipt_fields")
+        return {}
+    
+    # Field mapping from Azure Document Intelligence to internal keys
+    field_mappings = {
+        "merchant_name": {"azure_key": "merchant_name", "type": "string"},
+        "merchant_address": {"azure_key": "merchant_address", "type": "string"},
+        "merchant_phone": {"azure_key": "merchant_phone", "type": "string"},
+        "transaction_date": {"azure_key": "transaction_date", "type": "date"},
+        "transaction_time": {"azure_key": "transaction_time", "type": "time"},
+        "receipt_type": {"azure_key": "receipt_type", "type": "string"},
+        "subtotal": {"azure_key": "subtotal", "type": "decimal"},
+        "tax_amount": {"azure_key": "tax_amount", "type": "decimal"},
+        "total_amount": {"azure_key": "total_amount", "type": "decimal"},
+        "tip_amount": {"azure_key": "tip_amount", "type": "decimal"}
+    }
+    
+    # Create lookup dict for faster access
+    azure_field_lookup = {field["field_name"]: field for field in azure_fields}
+    
+    normalized_fields = {}
+    
+    for internal_key, config in field_mappings.items():
+        azure_key = config["azure_key"]
+        field_type = config["type"]
+        
+        # Get the field data from Azure results
+        field_data = azure_field_lookup.get(azure_key)
+        
+        if field_data:
+            raw_value = field_data.get("value", "")
+            confidence = field_data.get("confidence", 0.0)
+            
+            # Normalize the value based on type
+            normalized_value = _normalize_field_value(raw_value, field_type, internal_key)
+            
+            normalized_fields[internal_key] = {
+                "value": normalized_value,
+                "confidence": float(confidence),
+                "raw_value": str(raw_value) if raw_value is not None else "",
+                "field_type": field_type
+            }
+        else:
+            # Handle missing fields
+            normalized_fields[internal_key] = {
+                "value": None,
+                "confidence": 0.0,
+                "raw_value": "",
+                "field_type": field_type
+            }
+    
+    logger.info(f"Normalized {len([f for f in normalized_fields.values() if f['value'] is not None])}/{len(field_mappings)} receipt fields")
+    
+    return normalized_fields
+
+
+def normalize_line_items(azure_line_items: List[Dict[str, Any]], document_type: str = "invoice") -> List[Dict[str, Any]]:
+    """
+    Normalize line items from Azure Document Intelligence to internal format.
+    
+    Args:
+        azure_line_items: List of line items from Azure extraction
+        document_type: Type of document ("invoice" or "receipt")
+    
+    Returns:
+        List of normalized line items with consistent structure
+    """
+    if not azure_line_items or not isinstance(azure_line_items, list):
+        return []
+    
+    normalized_items = []
+    
+    for idx, item in enumerate(azure_line_items):
+        if not isinstance(item, dict):
+            continue
+        
+        # Normalize individual fields
+        description = _normalize_field_value(item.get("description", ""), "string", "description")
+        quantity = _normalize_field_value(item.get("quantity"), "decimal", "quantity")
+        unit_price = _normalize_field_value(item.get("unit_price"), "decimal", "unit_price")
+        total = _normalize_field_value(item.get("total"), "decimal", "total")
+        
+        # Default quantity to 1 if not provided or invalid
+        if quantity is None:
+            quantity = Decimal("1")
+        
+        normalized_item = {
+            "line_number": idx + 1,
+            "description": description,
+            "quantity": quantity,
+            "unit_price": unit_price,
+            "total": total,
+            "confidence": float(item.get("confidence", 0.0)),
+            "raw_data": item
+        }
+        
+        # Ensure we have at least description or total (including zero total)
+        if normalized_item["description"] or normalized_item["total"] is not None:
+            normalized_items.append(normalized_item)
+    
+    logger.info(f"Normalized {len(normalized_items)} line items for {document_type}")
+    return normalized_items
+
+
+def _normalize_field_value(
+    value: Any, 
+    field_type: str, 
+    field_name: str
+) -> Optional[Union[str, Decimal, datetime, date]]:
+    """
+    Normalize a single field value based on its expected type.
+    
+    Args:
+        value: Raw value from Azure
+        field_type: Expected type (string, decimal, date, time)
+        field_name: Field name for logging
+    
+    Returns:
+        Normalized value or None if conversion fails
+    """
+    if value is None or value == "":
+        return None
+    
+    try:
+        if field_type == "string":
+            return str(value).strip() if str(value).strip() else None
+        
+        elif field_type == "decimal":
+            if isinstance(value, (int, float)):
+                return Decimal(str(value))
+            elif isinstance(value, str):
+                # Clean up currency symbols and whitespace
+                clean_value = value.strip().replace("$", "").replace(",", "").replace(" ", "")
+                if clean_value:
+                    return Decimal(clean_value)
+            return None
+        
+        elif field_type == "date":
+            if isinstance(value, datetime):
+                return value.date()
+            elif isinstance(value, date):
+                return value
+            elif isinstance(value, str):
+                # Try common date formats
+                date_formats = [
+                    "%Y-%m-%d",
+                    "%m/%d/%Y", 
+                    "%d/%m/%Y",
+                    "%Y-%m-%d %H:%M:%S",
+                    "%m/%d/%Y %H:%M:%S"
+                ]
+                
+                for fmt in date_formats:
+                    try:
+                        parsed_date = datetime.strptime(value.strip(), fmt)
+                        return parsed_date.date()
+                    except ValueError:
+                        continue
+                
+                # If no format matches, return the original string
+                return value.strip()
+            return None
+        
+        elif field_type == "time":
+            return str(value).strip() if str(value).strip() else None
+        
+        else:
+            # Default to string
+            return str(value).strip() if str(value).strip() else None
+    
+    except (ValueError, InvalidOperation, TypeError) as e:
+        logger.warning(f"Failed to normalize field {field_name} with value '{value}' as {field_type}: {e}")
+        return None
+
+
+def get_field_confidence_summary(normalized_fields: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Calculate confidence statistics for normalized fields.
+    
+    Args:
+        normalized_fields: Output from normalize_invoice_fields or normalize_receipt_fields
+    
+    Returns:
+        Dictionary with confidence statistics
+    """
+    if not normalized_fields:
+        return {
+            "total_fields": 0, 
+            "fields_with_values": 0, 
+            "fields_without_values": 0,
+            "average_confidence": 0.0,
+            "high_confidence_fields": 0,
+            "medium_confidence_fields": 0,
+            "low_confidence_fields": 0,
+            "extraction_completeness": 0.0
+        }
+    
+    total_fields = len(normalized_fields)
+    fields_with_values = len([f for f in normalized_fields.values() if f["value"] is not None])
+    
+    confidences = [f["confidence"] for f in normalized_fields.values() if f["value"] is not None]
+    average_confidence = sum(confidences) / len(confidences) if confidences else 0.0
+    
+    # Categorize confidence levels
+    high_confidence = len([c for c in confidences if c >= 0.8])
+    medium_confidence = len([c for c in confidences if 0.5 <= c < 0.8])
+    low_confidence = len([c for c in confidences if c < 0.5])
+    
+    return {
+        "total_fields": total_fields,
+        "fields_with_values": fields_with_values,
+        "fields_without_values": total_fields - fields_with_values,
+        "average_confidence": round(average_confidence, 3),
+        "high_confidence_fields": high_confidence,
+        "medium_confidence_fields": medium_confidence,
+        "low_confidence_fields": low_confidence,
+        "extraction_completeness": round(fields_with_values / total_fields, 3) if total_fields > 0 else 0.0
+    }

--- a/backend/tests/demo_low_confidence.py
+++ b/backend/tests/demo_low_confidence.py
@@ -1,0 +1,45 @@
+"""
+Demonstration of low confidence flagging functionality.
+Shows how fields are flagged based on confidence scores.
+"""
+
+from app.routers.documents import is_low_confidence
+
+
+def demo_low_confidence_flagging():
+    """Demonstrate the low confidence flagging logic"""
+    
+    print("=== Low Confidence Flagging Demo ===\n")
+    
+    # Test various confidence scores
+    test_cases = [
+        (None, "No confidence score"),
+        (0.0, "Zero confidence"),
+        (0.3, "Low confidence (0.3)"),
+        (0.65, "Below threshold (0.65)"),
+        (0.69, "Just below threshold (0.69)"),
+        (0.7, "Exactly at threshold (0.7)"),
+        (0.71, "Just above threshold (0.71)"),
+        (0.8, "Good confidence (0.8)"),
+        (0.95, "High confidence (0.95)"),
+        (1.0, "Perfect confidence (1.0)")
+    ]
+    
+    print("Testing confidence scores against threshold (< 0.7):\n")
+    print(f"{'Confidence':<20} {'Description':<25} {'Is Low Confidence'}")
+    print("-" * 70)
+    
+    for confidence, description in test_cases:
+        is_low = is_low_confidence(confidence)
+        conf_str = str(confidence) if confidence is not None else "None"
+        print(f"{conf_str:<20} {description:<25} {is_low}")
+    
+    print("\n=== Summary ===")
+    print("✅ Fields with confidence >= 0.7 are NOT flagged as low confidence")
+    print("🚩 Fields with confidence < 0.7 ARE flagged as low confidence")
+    print("🚩 Fields with no confidence (None) ARE flagged as low confidence")
+    print("\nThis helps users identify fields that may need manual review.")
+
+
+if __name__ == "__main__":
+    demo_low_confidence_flagging()

--- a/backend/tests/test_document_fields_endpoint.py
+++ b/backend/tests/test_document_fields_endpoint.py
@@ -1,0 +1,469 @@
+"""
+Tests for GET /documents/{id}/fields endpoint.
+Tests both completed and pending document states.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from uuid import uuid4
+from decimal import Decimal
+
+from app.main import app
+from app.models import Business, User, Document, ExtractedField, LineItem
+from app.enums import DocumentStatus, DocumentType, FileType
+from app.auth import create_access_token, create_user_and_business
+from app.test_db import get_test_db, create_test_tables, drop_test_tables
+from app.db import get_db
+
+
+client = TestClient(app)
+
+# Override the dependency for testing to use the test database
+app.dependency_overrides[get_db] = lambda: next(get_test_db())
+
+
+@pytest.fixture(scope="module")
+def setup_database():
+    create_test_tables()
+    yield
+    drop_test_tables()
+
+
+@pytest.fixture
+def db_session(setup_database):
+    db = next(get_test_db())
+    try:
+        yield db
+    finally:
+        # Clean up test data
+        db.query(LineItem).delete()
+        db.query(ExtractedField).delete()
+        db.query(Document).delete()
+        db.query(User).delete()
+        db.query(Business).delete()
+        db.commit()
+        db.close()
+
+
+@pytest.fixture
+def test_user_and_token(db_session):
+    """Create a test user and JWT token"""
+    user = create_user_and_business(
+        db=db_session,
+        email="testuser@example.com",
+        password="testpassword123",
+        business_name="Test Business"
+    )
+    
+    # Create JWT token
+    token = create_access_token(data={"sub": user.email})
+    
+    return user, token
+
+
+class TestGetDocumentFields:
+    """Test GET /documents/{id}/fields endpoint"""
+    
+    def test_get_completed_document_fields_success(self, db_session: Session, test_user_and_token):
+        """Test getting fields from a completed document with extracted data"""
+        test_user, token = test_user_and_token
+        
+        # Create a completed document
+        document = Document(
+            user_id=test_user.id,
+            business_id=test_user.business_id,
+            filename="test_invoice.pdf",
+            file_url="https://example.com/test_invoice.pdf",
+            file_type=FileType.PDF,
+            document_type=DocumentType.INVOICE,
+            status=DocumentStatus.COMPLETED,
+            confidence_score=0.92
+        )
+        db_session.add(document)
+        db_session.commit()
+        db_session.refresh(document)
+        
+        # Add extracted fields
+        fields_data = [
+            {"field_name": "vendor_name", "value": "ACME Corp", "confidence": 0.95},
+            {"field_name": "invoice_number", "value": "INV-001", "confidence": 0.92},
+            {"field_name": "total_amount", "value": "1080.00", "confidence": 0.98},
+            {"field_name": "invoice_date", "value": "2024-01-15", "confidence": 0.90},
+            {"field_name": "tax_amount", "value": "80.00", "confidence": 0.89}
+        ]
+        
+        for field_data in fields_data:
+            field = ExtractedField(
+                document_id=document.id,
+                **field_data
+            )
+            db_session.add(field)
+        
+        # Add line items
+        line_items_data = [
+            {
+                "description": "Software License",
+                "quantity": Decimal("1"),
+                "unit_price": Decimal("1000.00"),
+                "total": Decimal("1000.00"),
+                "confidence": 0.94
+            },
+            {
+                "description": "Consulting Service",
+                "quantity": Decimal("2"),
+                "unit_price": Decimal("40.00"),
+                "total": Decimal("80.00"),
+                "confidence": 0.91
+            }
+        ]
+        
+        for item_data in line_items_data:
+            line_item = LineItem(
+                document_id=document.id,
+                **item_data
+            )
+            db_session.add(line_item)
+        
+        db_session.commit()
+        
+        # Use token from fixture
+        headers = {"Authorization": f"Bearer {token}"}
+        
+        # Make request
+        response = client.get(f"/documents/{document.id}/fields", headers=headers)
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Check structure
+        assert "document_id" in data
+        assert "document_info" in data
+        assert "extracted_fields" in data
+        assert "line_items" in data
+        assert "processing_status" in data
+        assert "overall_confidence" in data
+        assert "fields_summary" in data
+        assert "line_items_summary" in data
+        
+        # Check document info
+        assert data["document_id"] == str(document.id)
+        assert data["processing_status"] == "COMPLETED"
+        assert data["overall_confidence"] == 0.92
+        
+        doc_info = data["document_info"]
+        assert doc_info["filename"] == "test_invoice.pdf"
+        assert doc_info["document_type"] == "INVOICE"
+        assert doc_info["status"] == "COMPLETED"
+        
+        # Check extracted fields
+        fields = data["extracted_fields"]
+        assert len(fields) == 5
+        
+        vendor_field = next(f for f in fields if f["field_name"] == "vendor_name")
+        assert vendor_field["value"] == "ACME Corp"
+        assert vendor_field["confidence"] == 0.95
+        
+        total_field = next(f for f in fields if f["field_name"] == "total_amount")
+        assert total_field["value"] == "1080.00"
+        assert total_field["confidence"] == 0.98
+        
+        # Check line items
+        line_items = data["line_items"]
+        assert len(line_items) == 2
+        
+        software_item = next(item for item in line_items if item["description"] == "Software License")
+        assert software_item["quantity"] == 1.0
+        assert software_item["unit_price"] == 1000.0
+        assert software_item["total"] == 1000.0
+        assert software_item["confidence"] == 0.94
+        
+        # Check summaries
+        fields_summary = data["fields_summary"]
+        assert fields_summary["total_fields"] == 5
+        assert fields_summary["fields_with_values"] == 5
+        assert fields_summary["fields_without_values"] == 0
+        assert fields_summary["high_confidence_fields"] == 4  # >= 0.8
+        
+        line_items_summary = data["line_items_summary"]
+        assert line_items_summary["total_line_items"] == 2
+        assert line_items_summary["items_with_descriptions"] == 2
+        assert line_items_summary["items_with_totals"] == 2
+        assert line_items_summary["total_amount"] == 1080.0
+
+    def test_get_pending_document_fields_success(self, db_session: Session, test_user_and_token):
+        """Test getting fields from a pending document (no extracted data yet)"""
+        test_user, token = test_user_and_token
+        
+        # Create a pending document
+        document = Document(
+            user_id=test_user.id,
+            business_id=test_user.business_id,
+            filename="pending_receipt.pdf",
+            file_url="https://example.com/pending_receipt.pdf",
+            file_type=FileType.PDF,
+            document_type=DocumentType.RECEIPT,
+            status=DocumentStatus.PENDING,
+            confidence_score=None
+        )
+        db_session.add(document)
+        db_session.commit()
+        db_session.refresh(document)
+        
+        # Use token from fixture
+        headers = {"Authorization": f"Bearer {token}"}
+        
+        # Make request
+        response = client.get(f"/documents/{document.id}/fields", headers=headers)
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Check basic structure
+        assert data["document_id"] == str(document.id)
+        assert data["processing_status"] == "PENDING"
+        assert data["overall_confidence"] is None
+        
+        # Document info should be present
+        doc_info = data["document_info"]
+        assert doc_info["filename"] == "pending_receipt.pdf"
+        assert doc_info["document_type"] == "RECEIPT"
+        assert doc_info["status"] == "PENDING"
+        
+        # No extracted fields or line items yet
+        assert data["extracted_fields"] == []
+        assert data["line_items"] == []
+        
+        # Summaries should show empty state
+        fields_summary = data["fields_summary"]
+        assert fields_summary["total_fields"] == 0
+        assert fields_summary["fields_with_values"] == 0
+        assert fields_summary["average_confidence"] == 0.0
+        
+        line_items_summary = data["line_items_summary"]
+        assert line_items_summary["total_line_items"] == 0
+        assert line_items_summary["total_amount"] == 0.0
+
+    def test_get_processing_document_fields_success(self, db_session: Session, test_user_and_token):
+        """Test getting fields from a document currently being processed"""
+        # Create a processing document
+        document = Document(
+            user_id=test_user.id,
+            business_id=test_user.business_id,
+            filename="processing_invoice.pdf", 
+            file_url="https://example.com/processing_invoice.pdf",
+            file_type=FileType.PDF,
+            document_type=DocumentType.INVOICE,
+            status=DocumentStatus.PROCESSING,
+            confidence_score=None
+        )
+        db_session.add(document)
+        db_session.commit()
+        db_session.refresh(document)
+        
+        # Use token from fixture
+        headers = {"Authorization": f"Bearer {token}"}
+        
+        # Make request
+        response = client.get(f"/documents/{document.id}/fields", headers=headers)
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["processing_status"] == "PROCESSING"
+        assert data["overall_confidence"] is None
+        assert data["extracted_fields"] == []
+        assert data["line_items"] == []
+
+    def test_get_failed_document_fields_success(self, db_session: Session, test_user_and_token):
+        """Test getting fields from a failed document"""
+        # Create a failed document
+        document = Document(
+            user_id=test_user.id,
+            business_id=test_user.business_id,
+            filename="failed_document.pdf",
+            file_url="https://example.com/failed_document.pdf",
+            file_type=FileType.PDF,
+            document_type=DocumentType.INVOICE,
+            status=DocumentStatus.FAILED,
+            confidence_score=0.0
+        )
+        db_session.add(document)
+        db_session.commit()
+        db_session.refresh(document)
+        
+        # Use token from fixture
+        headers = {"Authorization": f"Bearer {token}"}
+        
+        # Make request
+        response = client.get(f"/documents/{document.id}/fields", headers=headers)
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["processing_status"] == "FAILED"
+        assert data["overall_confidence"] == 0.0
+        assert data["extracted_fields"] == []
+        assert data["line_items"] == []
+
+    def test_get_document_fields_not_found(self, test_user_and_token):
+        """Test getting fields for non-existent document"""
+        non_existent_id = uuid4()
+        
+        # Use token from fixture
+        headers = {"Authorization": f"Bearer {token}"}
+        
+        # Make request
+        response = client.get(f"/documents/{non_existent_id}/fields", headers=headers)
+        
+        # Assertions
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_get_document_fields_access_denied(self, db_session: Session, test_user_and_token):
+        """Test access denied when trying to access another business's document"""
+        # Create another business and user
+        other_business = Business(name="Other Business")
+        db_session.add(other_business)
+        db_session.commit()
+        
+        other_user = User(
+            email="other@example.com",
+            password_hash="hashed",
+            business_id=other_business.id
+        )
+        db_session.add(other_user)
+        db_session.commit()
+        
+        # Create document for other business
+        other_document = Document(
+            user_id=other_user.id,
+            business_id=other_business.id,
+            filename="other_invoice.pdf",
+            file_url="https://example.com/other_invoice.pdf",
+            file_type=FileType.PDF,
+            document_type=DocumentType.INVOICE,
+            status=DocumentStatus.COMPLETED
+        )
+        db_session.add(other_document)
+        db_session.commit()
+        
+        # Try to access with original user's token
+        token = create_access_token(data={"sub": test_user.email})
+        headers = {"Authorization": f"Bearer {token}"}
+        
+        response = client.get(f"/documents/{other_document.id}/fields", headers=headers)
+        
+        # Should be denied
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_get_document_fields_unauthorized(self, db_session: Session, test_user_and_token):
+        """Test unauthorized access without token"""
+        # Create a document
+        document = Document(
+            user_id=test_user.id,
+            business_id=test_user.business_id,
+            filename="test.pdf",
+            file_url="https://example.com/test.pdf",
+            file_type=FileType.PDF,
+            document_type=DocumentType.INVOICE,
+            status=DocumentStatus.COMPLETED
+        )
+        db_session.add(document)
+        db_session.commit()
+        
+        # Make request without token
+        response = client.get(f"/documents/{document.id}/fields")
+        
+        # Should be unauthorized
+        assert response.status_code == 401
+
+    def test_get_document_fields_with_partial_data(self, db_session: Session, test_user_and_token):
+        """Test getting fields from document with some missing/null values"""
+        # Create document
+        document = Document(
+            user_id=test_user.id,
+            business_id=test_user.business_id,
+            filename="partial_data.pdf",
+            file_url="https://example.com/partial_data.pdf",
+            file_type=FileType.PDF,
+            document_type=DocumentType.RECEIPT,
+            status=DocumentStatus.COMPLETED,
+            confidence_score=0.75
+        )
+        db_session.add(document)
+        db_session.commit()
+        db_session.refresh(document)
+        
+        # Add fields with some missing values
+        fields_data = [
+            {"field_name": "merchant_name", "value": "Coffee Shop", "confidence": 0.95},
+            {"field_name": "total_amount", "value": None, "confidence": 0.0},  # Missing value
+            {"field_name": "tax_amount", "value": "", "confidence": 0.0},  # Empty value
+            {"field_name": "transaction_date", "value": "2024-01-20", "confidence": 0.88}
+        ]
+        
+        for field_data in fields_data:
+            field = ExtractedField(
+                document_id=document.id,
+                **field_data
+            )
+            db_session.add(field)
+        
+        # Add line item with partial data
+        line_item = LineItem(
+            document_id=document.id,
+            description="Coffee",
+            quantity=None,  # Missing quantity
+            unit_price=None,  # Missing unit price
+            total=Decimal("5.50"),
+            confidence=0.80
+        )
+        db_session.add(line_item)
+        db_session.commit()
+        
+        # Create access token and make request
+        token = create_access_token(data={"sub": test_user.email})
+        headers = {"Authorization": f"Bearer {token}"}
+        
+        response = client.get(f"/documents/{document.id}/fields", headers=headers)
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Check fields summary accounts for missing values
+        fields_summary = data["fields_summary"]
+        assert fields_summary["total_fields"] == 4
+        assert fields_summary["fields_with_values"] == 2  # Only non-null, non-empty values
+        assert fields_summary["fields_without_values"] == 2
+        
+        # Check line items summary
+        line_items_summary = data["line_items_summary"]
+        assert line_items_summary["total_line_items"] == 1
+        assert line_items_summary["items_with_descriptions"] == 1
+        assert line_items_summary["items_with_totals"] == 1
+        assert line_items_summary["total_amount"] == 5.5
+        
+        # Check individual line item values
+        line_item_response = data["line_items"][0]
+        assert line_item_response["description"] == "Coffee"
+        assert line_item_response["quantity"] is None
+        assert line_item_response["unit_price"] is None
+        assert line_item_response["total"] == 5.5
+
+    def test_get_document_fields_invalid_uuid(self, test_user_and_token):
+        """Test getting fields with invalid document UUID"""
+        token = create_access_token(data={"sub": test_user.email})
+        headers = {"Authorization": f"Bearer {token}"}
+        
+        # Make request with invalid UUID
+        response = client.get("/documents/invalid-uuid/fields", headers=headers)
+        
+        # Should return 422 for validation error
+        assert response.status_code == 422

--- a/backend/tests/test_field_normalizer.py
+++ b/backend/tests/test_field_normalizer.py
@@ -1,0 +1,413 @@
+"""
+Tests for field normalization utilities.
+Tests mapping Azure Document Intelligence output to internal field keys and handling of missing/null values.
+"""
+
+import pytest
+from decimal import Decimal
+from datetime import date, datetime
+
+from app.services.field_normalizer import (
+    normalize_invoice_fields,
+    normalize_receipt_fields,
+    normalize_line_items,
+    _normalize_field_value,
+    get_field_confidence_summary
+)
+
+
+class TestNormalizeInvoiceFields:
+    """Test invoice field normalization"""
+    
+    def test_normalize_complete_invoice_fields(self):
+        """Test normalization with all fields present"""
+        azure_fields = [
+            {"field_name": "vendor_name", "value": "ACME Corporation", "confidence": 0.95},
+            {"field_name": "vendor_address", "value": "123 Main St, City, State 12345", "confidence": 0.88},
+            {"field_name": "invoice_number", "value": "INV-001", "confidence": 0.92},
+            {"field_name": "invoice_date", "value": "2024-01-15", "confidence": 0.90},
+            {"field_name": "due_date", "value": "2024-02-15", "confidence": 0.89},
+            {"field_name": "subtotal", "value": "1000.00", "confidence": 0.94},
+            {"field_name": "tax_amount", "value": "80.00", "confidence": 0.91},
+            {"field_name": "total_amount", "value": "1080.00", "confidence": 0.96}
+        ]
+        
+        result = normalize_invoice_fields(azure_fields)
+        
+        # Check structure
+        assert isinstance(result, dict)
+        assert len(result) == 15  # All possible invoice fields
+        
+        # Check specific fields
+        assert result["vendor_name"]["value"] == "ACME Corporation"
+        assert result["vendor_name"]["confidence"] == 0.95
+        assert result["vendor_name"]["raw_value"] == "ACME Corporation"
+        
+        assert result["invoice_number"]["value"] == "INV-001"
+        assert result["invoice_date"]["value"] == date(2024, 1, 15)
+        
+        # Check decimal fields
+        assert result["subtotal"]["value"] == Decimal("1000.00")
+        assert result["tax_amount"]["value"] == Decimal("80.00")
+        assert result["total_amount"]["value"] == Decimal("1080.00")
+        
+        # Check missing fields
+        assert result["customer_name"]["value"] is None
+        assert result["customer_name"]["confidence"] == 0.0
+        assert result["customer_name"]["raw_value"] == ""
+
+    def test_normalize_empty_invoice_fields(self):
+        """Test normalization with empty input"""
+        result = normalize_invoice_fields([])
+        assert result == {}
+        
+        result = normalize_invoice_fields(None)
+        assert result == {}
+
+    def test_normalize_invoice_fields_with_nulls(self):
+        """Test normalization with null/empty values"""
+        azure_fields = [
+            {"field_name": "vendor_name", "value": "", "confidence": 0.0},
+            {"field_name": "invoice_number", "value": None, "confidence": 0.0},
+            {"field_name": "total_amount", "value": "500.50", "confidence": 0.85}
+        ]
+        
+        result = normalize_invoice_fields(azure_fields)
+        
+        assert result["vendor_name"]["value"] is None
+        assert result["invoice_number"]["value"] is None
+        assert result["total_amount"]["value"] == Decimal("500.50")
+
+    def test_normalize_invoice_fields_invalid_decimals(self):
+        """Test normalization with invalid decimal values"""
+        azure_fields = [
+            {"field_name": "subtotal", "value": "not-a-number", "confidence": 0.8},
+            {"field_name": "tax_amount", "value": "$invalid$", "confidence": 0.7},
+            {"field_name": "total_amount", "value": "1,234.56", "confidence": 0.9}
+        ]
+        
+        result = normalize_invoice_fields(azure_fields)
+        
+        assert result["subtotal"]["value"] is None
+        assert result["tax_amount"]["value"] is None
+        assert result["total_amount"]["value"] == Decimal("1234.56")  # Commas should be cleaned
+
+
+class TestNormalizeReceiptFields:
+    """Test receipt field normalization"""
+    
+    def test_normalize_complete_receipt_fields(self):
+        """Test normalization with all fields present"""
+        azure_fields = [
+            {"field_name": "merchant_name", "value": "Best Buy", "confidence": 0.97},
+            {"field_name": "merchant_address", "value": "456 Tech Ave, Silicon Valley, CA", "confidence": 0.85},
+            {"field_name": "merchant_phone", "value": "(555) 123-4567", "confidence": 0.88},
+            {"field_name": "transaction_date", "value": "2024-01-20", "confidence": 0.93},
+            {"field_name": "transaction_time", "value": "14:30:00", "confidence": 0.89},
+            {"field_name": "subtotal", "value": "299.99", "confidence": 0.95},
+            {"field_name": "tax_amount", "value": "24.00", "confidence": 0.92},
+            {"field_name": "total_amount", "value": "323.99", "confidence": 0.98},
+            {"field_name": "tip_amount", "value": "0.00", "confidence": 0.90}
+        ]
+        
+        result = normalize_receipt_fields(azure_fields)
+        
+        # Check structure
+        assert isinstance(result, dict)
+        assert len(result) == 10  # All possible receipt fields
+        
+        # Check specific fields
+        assert result["merchant_name"]["value"] == "Best Buy"
+        assert result["merchant_name"]["confidence"] == 0.97
+        
+        assert result["merchant_phone"]["value"] == "(555) 123-4567"
+        assert result["transaction_time"]["value"] == "14:30:00"
+        
+        # Check decimal fields
+        assert result["subtotal"]["value"] == Decimal("299.99")
+        assert result["tax_amount"]["value"] == Decimal("24.00")
+        assert result["total_amount"]["value"] == Decimal("323.99")
+        assert result["tip_amount"]["value"] == Decimal("0.00")
+
+    def test_normalize_empty_receipt_fields(self):
+        """Test normalization with empty input"""
+        result = normalize_receipt_fields([])
+        assert result == {}
+        
+        result = normalize_receipt_fields(None)
+        assert result == {}
+
+    def test_normalize_receipt_fields_partial(self):
+        """Test normalization with only some fields present"""
+        azure_fields = [
+            {"field_name": "merchant_name", "value": "Coffee Shop", "confidence": 0.92},
+            {"field_name": "total_amount", "value": "15.75", "confidence": 0.96}
+        ]
+        
+        result = normalize_receipt_fields(azure_fields)
+        
+        assert result["merchant_name"]["value"] == "Coffee Shop"
+        assert result["total_amount"]["value"] == Decimal("15.75")
+        assert result["merchant_address"]["value"] is None
+        assert result["tax_amount"]["value"] is None
+
+
+class TestNormalizeLineItems:
+    """Test line item normalization"""
+    
+    def test_normalize_invoice_line_items(self):
+        """Test normalization of invoice line items"""
+        azure_line_items = [
+            {
+                "description": "Widget A",
+                "quantity": 2,
+                "unit_price": "25.00",
+                "total": "50.00",
+                "confidence": 0.95
+            },
+            {
+                "description": "Service Fee",
+                "quantity": 1,
+                "unit_price": "10.00",
+                "total": "10.00",
+                "confidence": 0.88
+            }
+        ]
+        
+        result = normalize_line_items(azure_line_items, "invoice")
+        
+        assert len(result) == 2
+        
+        # Check first item
+        item1 = result[0]
+        assert item1["line_number"] == 1
+        assert item1["description"] == "Widget A"
+        assert item1["quantity"] == Decimal("2")
+        assert item1["unit_price"] == Decimal("25.00")
+        assert item1["total"] == Decimal("50.00")
+        assert item1["confidence"] == 0.95
+        
+        # Check second item
+        item2 = result[1]
+        assert item2["line_number"] == 2
+        assert item2["description"] == "Service Fee"
+        assert item2["quantity"] == Decimal("1")
+
+    def test_normalize_line_items_empty(self):
+        """Test normalization with empty line items"""
+        result = normalize_line_items([])
+        assert result == []
+        
+        result = normalize_line_items(None)
+        assert result == []
+
+    def test_normalize_line_items_missing_data(self):
+        """Test normalization with missing data in line items"""
+        azure_line_items = [
+            {
+                "description": "Unknown Item",
+                "confidence": 0.75
+                # Missing quantity, unit_price, total
+            },
+            {
+                "total": "100.00",
+                "confidence": 0.90
+                # Missing description, quantity, unit_price
+            }
+        ]
+        
+        result = normalize_line_items(azure_line_items)
+        
+        assert len(result) == 2
+        
+        # First item - has description
+        assert result[0]["description"] == "Unknown Item"
+        assert result[0]["quantity"] == Decimal("1")  # Default quantity
+        assert result[0]["unit_price"] is None
+        assert result[0]["total"] is None
+        
+        # Second item - has total
+        assert result[1]["description"] is None
+        assert result[1]["total"] == Decimal("100.00")
+
+
+class TestNormalizeFieldValue:
+    """Test individual field value normalization"""
+    
+    def test_normalize_string_values(self):
+        """Test string value normalization"""
+        assert _normalize_field_value("  Test String  ", "string", "test") == "Test String"
+        assert _normalize_field_value("", "string", "test") is None
+        assert _normalize_field_value(None, "string", "test") is None
+        assert _normalize_field_value(123, "string", "test") == "123"
+
+    def test_normalize_decimal_values(self):
+        """Test decimal value normalization"""
+        assert _normalize_field_value("123.45", "decimal", "test") == Decimal("123.45")
+        assert _normalize_field_value("$1,234.56", "decimal", "test") == Decimal("1234.56")
+        assert _normalize_field_value(100, "decimal", "test") == Decimal("100")
+        assert _normalize_field_value(99.99, "decimal", "test") == Decimal("99.99")
+        assert _normalize_field_value("invalid", "decimal", "test") is None
+        assert _normalize_field_value("", "decimal", "test") is None
+
+    def test_normalize_date_values(self):
+        """Test date value normalization"""
+        # ISO format
+        result = _normalize_field_value("2024-01-15", "date", "test")
+        assert result == date(2024, 1, 15)
+        
+        # US format
+        result = _normalize_field_value("01/15/2024", "date", "test")
+        assert result == date(2024, 1, 15)
+        
+        # Datetime object
+        dt = datetime(2024, 1, 15, 10, 30, 0)
+        result = _normalize_field_value(dt, "date", "test")
+        assert result == date(2024, 1, 15)
+        
+        # Date object
+        d = date(2024, 1, 15)
+        result = _normalize_field_value(d, "date", "test")
+        assert result == date(2024, 1, 15)
+        
+        # Invalid format - return as string
+        result = _normalize_field_value("invalid-date", "date", "test")
+        assert result == "invalid-date"
+
+    def test_normalize_time_values(self):
+        """Test time value normalization"""
+        assert _normalize_field_value("14:30:00", "time", "test") == "14:30:00"
+        assert _normalize_field_value("  2:30 PM  ", "time", "test") == "2:30 PM"
+        assert _normalize_field_value("", "time", "test") is None
+
+    def test_normalize_unknown_type(self):
+        """Test normalization with unknown field type"""
+        assert _normalize_field_value("test", "unknown_type", "test") == "test"
+        assert _normalize_field_value(123, "unknown_type", "test") == "123"
+
+
+class TestFieldConfidenceSummary:
+    """Test confidence summary calculations"""
+    
+    def test_confidence_summary_complete_fields(self):
+        """Test confidence summary with complete field data"""
+        normalized_fields = {
+            "field1": {"value": "test1", "confidence": 0.9, "raw_value": "test1"},
+            "field2": {"value": "test2", "confidence": 0.8, "raw_value": "test2"},
+            "field3": {"value": "test3", "confidence": 0.6, "raw_value": "test3"},
+            "field4": {"value": None, "confidence": 0.0, "raw_value": ""},
+            "field5": {"value": "test5", "confidence": 0.4, "raw_value": "test5"}
+        }
+        
+        result = get_field_confidence_summary(normalized_fields)
+        
+        assert result["total_fields"] == 5
+        assert result["fields_with_values"] == 4
+        assert result["fields_without_values"] == 1
+        assert result["average_confidence"] == 0.675  # (0.9 + 0.8 + 0.6 + 0.4) / 4
+        assert result["high_confidence_fields"] == 2  # >= 0.8
+        assert result["medium_confidence_fields"] == 1  # 0.5 <= x < 0.8
+        assert result["low_confidence_fields"] == 1  # < 0.5
+        assert result["extraction_completeness"] == 0.8  # 4/5
+
+    def test_confidence_summary_empty_fields(self):
+        """Test confidence summary with empty fields"""
+        result = get_field_confidence_summary({})
+        
+        assert result["total_fields"] == 0
+        assert result["fields_with_values"] == 0
+        assert result["average_confidence"] == 0.0
+        assert result["extraction_completeness"] == 0.0
+
+    def test_confidence_summary_no_values(self):
+        """Test confidence summary with no field values"""
+        normalized_fields = {
+            "field1": {"value": None, "confidence": 0.0, "raw_value": ""},
+            "field2": {"value": None, "confidence": 0.0, "raw_value": ""}
+        }
+        
+        result = get_field_confidence_summary(normalized_fields)
+        
+        assert result["total_fields"] == 2
+        assert result["fields_with_values"] == 0
+        assert result["average_confidence"] == 0.0
+        assert result["extraction_completeness"] == 0.0
+
+
+class TestIntegrationScenarios:
+    """Test real-world integration scenarios"""
+    
+    def test_invoice_with_currency_symbols(self):
+        """Test invoice normalization with currency symbols and formatting"""
+        azure_fields = [
+            {"field_name": "vendor_name", "value": "Tech Solutions Inc.", "confidence": 0.96},
+            {"field_name": "subtotal", "value": "$2,500.00", "confidence": 0.94},
+            {"field_name": "tax_amount", "value": "$200.00", "confidence": 0.92},
+            {"field_name": "total_amount", "value": "$2,700.00", "confidence": 0.95}
+        ]
+        
+        result = normalize_invoice_fields(azure_fields)
+        
+        assert result["subtotal"]["value"] == Decimal("2500.00")
+        assert result["tax_amount"]["value"] == Decimal("200.00")
+        assert result["total_amount"]["value"] == Decimal("2700.00")
+
+    def test_receipt_with_minimal_data(self):
+        """Test receipt normalization with minimal data"""
+        azure_fields = [
+            {"field_name": "merchant_name", "value": "Quick Mart", "confidence": 0.88},
+            {"field_name": "total_amount", "value": "12.34", "confidence": 0.92}
+        ]
+        
+        result = normalize_receipt_fields(azure_fields)
+        summary = get_field_confidence_summary(result)
+        
+        assert result["merchant_name"]["value"] == "Quick Mart"
+        assert result["total_amount"]["value"] == Decimal("12.34")
+        assert summary["fields_with_values"] == 2
+        assert summary["extraction_completeness"] == 0.2  # 2/10 possible fields
+
+    def test_line_items_with_edge_cases(self):
+        """Test line item normalization with edge cases"""
+        azure_line_items = [
+            {
+                "description": "  Product with spaces  ",
+                "quantity": "2.5",
+                "unit_price": "$15.99",
+                "total": "$39.98",
+                "confidence": 0.93
+            },
+            {
+                "description": "",
+                "total": "0.00",
+                "confidence": 0.1
+            },
+            {
+                "description": "Valid Item",
+                "quantity": "invalid",
+                "unit_price": "not-a-number",
+                "total": "25.00",
+                "confidence": 0.85
+            }
+        ]
+        
+        result = normalize_line_items(azure_line_items)
+        
+        # Should have 3 valid items (all items have at least description or total)
+        assert len(result) == 3
+        
+        # First item - properly cleaned
+        assert result[0]["description"] == "Product with spaces"
+        assert result[0]["quantity"] == Decimal("2.5")
+        assert result[0]["unit_price"] == Decimal("15.99")
+        assert result[0]["total"] == Decimal("39.98")
+        
+        # Second item - empty description but has total
+        assert result[1]["description"] is None
+        assert result[1]["total"] == Decimal("0.00")
+        
+        # Third item - invalid numbers handled gracefully
+        assert result[2]["description"] == "Valid Item"
+        assert result[2]["quantity"] == Decimal("1")  # Default when invalid
+        assert result[2]["unit_price"] is None
+        assert result[2]["total"] == Decimal("25.00")

--- a/backend/tests/test_low_confidence_flagging.py
+++ b/backend/tests/test_low_confidence_flagging.py
@@ -1,0 +1,430 @@
+"""
+Tests for low confidence flagging functionality.
+Tests that fields with confidence < 0.7 are flagged as is_low_confidence = True.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from decimal import Decimal
+
+from app.main import app
+from app.models import Business, User, Document, ExtractedField, LineItem
+from app.enums import DocumentStatus, DocumentType, FileType
+from app.auth import create_access_token, create_user_and_business
+from app.test_db import get_test_db, create_test_tables, drop_test_tables
+from app.db import get_db
+from app.routers.documents import is_low_confidence
+
+
+client = TestClient(app)
+
+# Override the dependency for testing to use the test database
+app.dependency_overrides[get_db] = lambda: next(get_test_db())
+
+
+@pytest.fixture(scope="module")
+def setup_database():
+    create_test_tables()
+    yield
+    drop_test_tables()
+
+
+@pytest.fixture
+def db_session(setup_database):
+    db = next(get_test_db())
+    try:
+        yield db
+    finally:
+        # Clean up test data
+        db.query(LineItem).delete()
+        db.query(ExtractedField).delete()
+        db.query(Document).delete()
+        db.query(User).delete()
+        db.query(Business).delete()
+        db.commit()
+        db.close()
+
+
+@pytest.fixture
+def test_user_and_token(db_session):
+    """Create a test user and JWT token"""
+    user = create_user_and_business(
+        db=db_session,
+        email="testuser@example.com",
+        password="testpassword123",
+        business_name="Test Business"
+    )
+    
+    # Create JWT token
+    token = create_access_token(data={"sub": user.email})
+    
+    return user, token
+
+
+class TestLowConfidenceFlagging:
+    """Test low confidence flagging functionality"""
+    
+    def test_is_low_confidence_function(self):
+        """Test the is_low_confidence helper function"""
+        # Test various confidence scores
+        assert is_low_confidence(None) == True  # None should be low confidence
+        assert is_low_confidence(0.0) == True   # 0.0 < 0.7
+        assert is_low_confidence(0.3) == True   # 0.3 < 0.7
+        assert is_low_confidence(0.6) == True   # 0.6 < 0.7
+        assert is_low_confidence(0.69) == True  # 0.69 < 0.7
+        
+        # These should NOT be low confidence
+        assert is_low_confidence(0.7) == False  # 0.7 = 0.7 (not less than)
+        assert is_low_confidence(0.8) == False  # 0.8 > 0.7
+        assert is_low_confidence(0.95) == False # 0.95 > 0.7
+        assert is_low_confidence(1.0) == False  # 1.0 > 0.7
+
+    def test_mixed_confidence_scores_in_fields(self, db_session: Session, test_user_and_token):
+        """Test document with mixed confidence scores in extracted fields"""
+        test_user, token = test_user_and_token
+        
+        # Create a completed document
+        document = Document(
+            user_id=test_user.id,
+            business_id=test_user.business_id,
+            filename="mixed_confidence_invoice.pdf",
+            file_url="https://example.com/mixed_confidence_invoice.pdf",
+            file_type=FileType.PDF,
+            document_type=DocumentType.INVOICE,
+            status=DocumentStatus.COMPLETED,
+            confidence_score=0.75
+        )
+        db_session.add(document)
+        db_session.commit()
+        db_session.refresh(document)
+        
+        # Add extracted fields with mixed confidence scores
+        fields_data = [
+            {"field_name": "vendor_name", "value": "High Confidence Corp", "confidence": 0.95},      # High confidence
+            {"field_name": "invoice_number", "value": "INV-001", "confidence": 0.8},                 # High confidence  
+            {"field_name": "total_amount", "value": "1000.00", "confidence": 0.7},                   # Exactly at threshold
+            {"field_name": "invoice_date", "value": "2024-01-15", "confidence": 0.65},               # Low confidence
+            {"field_name": "tax_amount", "value": "80.00", "confidence": 0.3},                       # Very low confidence
+            {"field_name": "due_date", "value": "Unclear date", "confidence": None},                 # No confidence (None)
+        ]
+        
+        for field_data in fields_data:
+            field = ExtractedField(
+                document_id=document.id,
+                **field_data
+            )
+            db_session.add(field)
+        
+        db_session.commit()
+        
+        # Make request to get document fields
+        headers = {"Authorization": f"Bearer {token}"}
+        response = client.get(f"/documents/{document.id}/fields", headers=headers)
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Check extracted fields flagging
+        fields = data["extracted_fields"]
+        assert len(fields) == 6
+        
+        # Create lookup for easier testing
+        field_lookup = {f["field_name"]: f for f in fields}
+        
+        # Test high confidence fields (should NOT be flagged)
+        vendor_field = field_lookup["vendor_name"]
+        assert vendor_field["confidence"] == 0.95
+        assert vendor_field["is_low_confidence"] == False
+        
+        invoice_num_field = field_lookup["invoice_number"]
+        assert invoice_num_field["confidence"] == 0.8
+        assert invoice_num_field["is_low_confidence"] == False
+        
+        # Test exactly at threshold (0.7 should NOT be flagged as low confidence)
+        total_field = field_lookup["total_amount"]
+        assert total_field["confidence"] == 0.7
+        assert total_field["is_low_confidence"] == False
+        
+        # Test low confidence fields (should be flagged)
+        date_field = field_lookup["invoice_date"]
+        assert date_field["confidence"] == 0.65
+        assert date_field["is_low_confidence"] == True
+        
+        tax_field = field_lookup["tax_amount"]
+        assert tax_field["confidence"] == 0.3
+        assert tax_field["is_low_confidence"] == True
+        
+        # Test None confidence (should be flagged)
+        due_date_field = field_lookup["due_date"]
+        assert due_date_field["confidence"] is None
+        assert due_date_field["is_low_confidence"] == True
+
+    def test_mixed_confidence_scores_in_line_items(self, db_session: Session, test_user_and_token):
+        """Test document with mixed confidence scores in line items"""
+        test_user, token = test_user_and_token
+        
+        # Create a completed document
+        document = Document(
+            user_id=test_user.id,
+            business_id=test_user.business_id,
+            filename="mixed_line_items.pdf",
+            file_url="https://example.com/mixed_line_items.pdf",
+            file_type=FileType.PDF,
+            document_type=DocumentType.RECEIPT,
+            status=DocumentStatus.COMPLETED,
+            confidence_score=0.72
+        )
+        db_session.add(document)
+        db_session.commit()
+        db_session.refresh(document)
+        
+        # Add line items with mixed confidence scores
+        line_items_data = [
+            {
+                "description": "Clear Item Description",
+                "quantity": Decimal("2"),
+                "unit_price": Decimal("50.00"),
+                "total": Decimal("100.00"),
+                "confidence": 0.92  # High confidence
+            },
+            {
+                "description": "Somewhat Clear Item",
+                "quantity": Decimal("1"),
+                "unit_price": Decimal("25.00"),
+                "total": Decimal("25.00"),
+                "confidence": 0.7  # Exactly at threshold
+            },
+            {
+                "description": "Unclear Item",
+                "quantity": Decimal("3"),
+                "unit_price": Decimal("10.00"),
+                "total": Decimal("30.00"),
+                "confidence": 0.55  # Low confidence
+            },
+            {
+                "description": "Very Unclear Item",
+                "quantity": Decimal("1"),
+                "unit_price": Decimal("15.00"),
+                "total": Decimal("15.00"),
+                "confidence": 0.2  # Very low confidence
+            },
+            {
+                "description": "No Confidence Item",
+                "quantity": Decimal("1"),
+                "unit_price": Decimal("5.00"),
+                "total": Decimal("5.00"),
+                "confidence": None  # No confidence
+            }
+        ]
+        
+        for item_data in line_items_data:
+            line_item = LineItem(
+                document_id=document.id,
+                **item_data
+            )
+            db_session.add(line_item)
+        
+        db_session.commit()
+        
+        # Make request to get document fields
+        headers = {"Authorization": f"Bearer {token}"}
+        response = client.get(f"/documents/{document.id}/fields", headers=headers)
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Check line items flagging
+        line_items = data["line_items"]
+        assert len(line_items) == 5
+        
+        # Test high confidence item (should NOT be flagged)
+        clear_item = next(item for item in line_items if item["description"] == "Clear Item Description")
+        assert clear_item["confidence"] == 0.92
+        assert clear_item["is_low_confidence"] == False
+        
+        # Test exactly at threshold (should NOT be flagged)
+        threshold_item = next(item for item in line_items if item["description"] == "Somewhat Clear Item")
+        assert threshold_item["confidence"] == 0.7
+        assert threshold_item["is_low_confidence"] == False
+        
+        # Test low confidence items (should be flagged)
+        unclear_item = next(item for item in line_items if item["description"] == "Unclear Item")
+        assert unclear_item["confidence"] == 0.55
+        assert unclear_item["is_low_confidence"] == True
+        
+        very_unclear_item = next(item for item in line_items if item["description"] == "Very Unclear Item")
+        assert very_unclear_item["confidence"] == 0.2
+        assert very_unclear_item["is_low_confidence"] == True
+        
+        # Test None confidence (should be flagged)
+        no_confidence_item = next(item for item in line_items if item["description"] == "No Confidence Item")
+        assert no_confidence_item["confidence"] is None
+        assert no_confidence_item["is_low_confidence"] == True
+
+    def test_all_high_confidence_fields(self, db_session: Session, test_user_and_token):
+        """Test document where all fields have high confidence"""
+        test_user, token = test_user_and_token
+        
+        # Create a completed document
+        document = Document(
+            user_id=test_user.id,
+            business_id=test_user.business_id,
+            filename="high_confidence_invoice.pdf",
+            file_url="https://example.com/high_confidence_invoice.pdf",
+            file_type=FileType.PDF,
+            document_type=DocumentType.INVOICE,
+            status=DocumentStatus.COMPLETED,
+            confidence_score=0.95
+        )
+        db_session.add(document)
+        db_session.commit()
+        db_session.refresh(document)
+        
+        # Add extracted fields with high confidence scores
+        fields_data = [
+            {"field_name": "vendor_name", "value": "Perfect Corp", "confidence": 0.98},
+            {"field_name": "total_amount", "value": "500.00", "confidence": 0.95},
+            {"field_name": "invoice_date", "value": "2024-01-15", "confidence": 0.92}
+        ]
+        
+        for field_data in fields_data:
+            field = ExtractedField(
+                document_id=document.id,
+                **field_data
+            )
+            db_session.add(field)
+        
+        db_session.commit()
+        
+        # Make request
+        headers = {"Authorization": f"Bearer {token}"}
+        response = client.get(f"/documents/{document.id}/fields", headers=headers)
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        
+        # All fields should have is_low_confidence = False
+        fields = data["extracted_fields"]
+        for field in fields:
+            assert field["is_low_confidence"] == False
+            assert field["confidence"] >= 0.7
+
+    def test_all_low_confidence_fields(self, db_session: Session, test_user_and_token):
+        """Test document where all fields have low confidence"""
+        test_user, token = test_user_and_token
+        
+        # Create a completed document
+        document = Document(
+            user_id=test_user.id,
+            business_id=test_user.business_id,
+            filename="low_confidence_invoice.pdf",
+            file_url="https://example.com/low_confidence_invoice.pdf",
+            file_type=FileType.PDF,
+            document_type=DocumentType.INVOICE,
+            status=DocumentStatus.COMPLETED,
+            confidence_score=0.45
+        )
+        db_session.add(document)
+        db_session.commit()
+        db_session.refresh(document)
+        
+        # Add extracted fields with low confidence scores
+        fields_data = [
+            {"field_name": "vendor_name", "value": "Unclear Corp", "confidence": 0.6},
+            {"field_name": "total_amount", "value": "???", "confidence": 0.2},
+            {"field_name": "invoice_date", "value": "Unreadable", "confidence": 0.1}
+        ]
+        
+        for field_data in fields_data:
+            field = ExtractedField(
+                document_id=document.id,
+                **field_data
+            )
+            db_session.add(field)
+        
+        db_session.commit()
+        
+        # Make request
+        headers = {"Authorization": f"Bearer {token}"}
+        response = client.get(f"/documents/{document.id}/fields", headers=headers)
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        
+        # All fields should have is_low_confidence = True
+        fields = data["extracted_fields"]
+        for field in fields:
+            assert field["is_low_confidence"] == True
+            assert field["confidence"] < 0.7
+
+    def test_edge_case_confidence_values(self, db_session: Session, test_user_and_token):
+        """Test edge cases around the 0.7 threshold"""
+        test_user, token = test_user_and_token
+        
+        # Create a completed document
+        document = Document(
+            user_id=test_user.id,
+            business_id=test_user.business_id,
+            filename="edge_case_confidence.pdf",
+            file_url="https://example.com/edge_case_confidence.pdf",
+            file_type=FileType.PDF,
+            document_type=DocumentType.INVOICE,
+            status=DocumentStatus.COMPLETED,
+            confidence_score=0.7
+        )
+        db_session.add(document)
+        db_session.commit()
+        db_session.refresh(document)
+        
+        # Add extracted fields with edge case confidence scores
+        fields_data = [
+            {"field_name": "exactly_threshold", "value": "Exactly 0.7", "confidence": 0.7},
+            {"field_name": "just_above", "value": "Just above", "confidence": 0.700001},
+            {"field_name": "just_below", "value": "Just below", "confidence": 0.699999},
+            {"field_name": "zero_confidence", "value": "Zero", "confidence": 0.0},
+            {"field_name": "perfect_confidence", "value": "Perfect", "confidence": 1.0}
+        ]
+        
+        for field_data in fields_data:
+            field = ExtractedField(
+                document_id=document.id,
+                **field_data
+            )
+            db_session.add(field)
+        
+        db_session.commit()
+        
+        # Make request
+        headers = {"Authorization": f"Bearer {token}"}
+        response = client.get(f"/documents/{document.id}/fields", headers=headers)
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        
+        field_lookup = {f["field_name"]: f for f in data["extracted_fields"]}
+        
+        # Exactly 0.7 should NOT be flagged as low confidence
+        assert field_lookup["exactly_threshold"]["confidence"] == 0.7
+        assert field_lookup["exactly_threshold"]["is_low_confidence"] == False
+        
+        # Just above 0.7 should NOT be flagged
+        assert field_lookup["just_above"]["confidence"] > 0.7
+        assert field_lookup["just_above"]["is_low_confidence"] == False
+        
+        # Just below 0.7 should be flagged
+        assert field_lookup["just_below"]["confidence"] < 0.7
+        assert field_lookup["just_below"]["is_low_confidence"] == True
+        
+        # Zero confidence should be flagged
+        assert field_lookup["zero_confidence"]["confidence"] == 0.0
+        assert field_lookup["zero_confidence"]["is_low_confidence"] == True
+        
+        # Perfect confidence should NOT be flagged
+        assert field_lookup["perfect_confidence"]["confidence"] == 1.0
+        assert field_lookup["perfect_confidence"]["is_low_confidence"] == False

--- a/backend/tests/test_simple_document_fields.py
+++ b/backend/tests/test_simple_document_fields.py
@@ -1,0 +1,53 @@
+"""
+Simple test for GET /documents/{id}/fields endpoint to verify it works
+"""
+
+import pytest
+import requests
+from uuid import uuid4
+
+# Use the correct port for testing
+BASE_URL = "http://localhost:8001"
+
+
+def test_document_fields_endpoint_not_found():
+    """Test that the endpoint exists and returns 404 for non-existent document"""
+    # First create a test user to get a token
+    signup_response = requests.post(
+        f"{BASE_URL}/auth/signup",
+        json={
+            "email": f"test_{uuid4()}@example.com",
+            "password": "testpass123",
+            "business_name": "Test Business"
+        }
+    )
+    assert signup_response.status_code == 200
+    
+    token = signup_response.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    
+    # Test the fields endpoint with non-existent document
+    non_existent_id = uuid4()
+    response = requests.get(
+        f"{BASE_URL}/documents/{non_existent_id}/fields",
+        headers=headers
+    )
+    
+    # Should return 404
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_document_fields_endpoint_unauthorized():
+    """Test that the endpoint requires authentication"""
+    non_existent_id = uuid4()
+    response = requests.get(f"{BASE_URL}/documents/{non_existent_id}/fields")
+    
+    # Should return 401 unauthorized
+    assert response.status_code == 401
+
+
+if __name__ == "__main__":
+    test_document_fields_endpoint_not_found()
+    test_document_fields_endpoint_unauthorized()
+    print("✅ All manual tests passed!")


### PR DESCRIPTION
# 1. Built GET /documents/{id}/fields API

## 1.1 Purpose 
Retrieves comprehensive extraction results for any document, regardless of processing state.

What it returns:
- Document metadata (filename, status, confidence, type)
- All extracted fields with confidence scores
- All line items with quantities, prices, totals
- Statistical summaries (field counts, confidence analysis)
- Works for PENDING (empty results), PROCESSING (in-progress), COMPLETED (full data), and FAILED states

## 1.2 How to test via Curl

### Step 1: Create a test user and get an access token
```
curl -X POST "http://localhost:8001/auth/signup" \
-H "Content-Type: application/json" \
-d '{
"email": "[test@example.com](mailto:test@example.com)",
"password": "testpass123",
"business_name": "Test Business"
}'
```

### Step 2: Save the access token from the response
Look for "access_token": "eyJ..." in the response and copy it.

### Step 3: Test with non-existent document (should return 404)
curl -X GET "http://localhost:8001/documents/01234567-89ab-cdef-0123-456789abcdef/fields" \
-H "Authorization: Bearer YOUR_ACCESS_TOKEN_HERE"

### Step 4: Upload a real document to get a valid document ID
```
curl -X POST "http://localhost:8001/documents/upload" \
-H "Authorization: Bearer YOUR_ACCESS_TOKEN_HERE" \
-F "files=@/path/to/your/document.pdf"
```

### Step 5: Test with real document ID (from upload response)
```
curl -X GET "http://localhost:8001/documents/REAL_DOCUMENT_ID_HERE/fields" \
-H "Authorization: Bearer YOUR_ACCESS_TOKEN_HERE"
```

## 1.3 What to Observe

✅ Working (Status 200):
```
{
  "document_id": "12345678-1234-1234-1234-123456789abc",
  "document_info": {
    "id": "12345678-1234-1234-1234-123456789abc",
    "filename": "invoice.pdf",
    "status": "COMPLETED",
    "document_type": "INVOICE",
    "confidence_score": 0.85
  },
  "extracted_fields": [
    {
      "id": 1,
      "field_name": "vendor_name",
      "value": "ACME Corp",
      "confidence": 0.95,
      "is_low_confidence": false
    }
  ],
  "line_items": [
    {
      "id": 1,
      "description": "Software License",
      "quantity": 1.0,
      "total": 100.0,
      "confidence": 0.92,
      "is_low_confidence": false
    }
  ],
  "processing_status": "COMPLETED",
  "fields_summary": {
    "total_fields": 5,
    "fields_with_values": 4,
    "flagged_low_confidence_fields": 1
  },
  "line_items_summary": {
    "total_line_items": 2,
    "flagged_low_confidence_items": 0
  }
}
```
❌ Not Working:
- 404 Error: {"detail":"Document not found or access denied"}
- 401 Error: {"detail":"Not authenticated"} (wrong/missing token)
- 422 Error: {"detail":[{"type":"uuid_parsing"...}]} (invalid UUID format)

---

# 2 Low Confidence Flagging 

## 2.1 Purpose
Automatically identifies extracted fields that may need manual review due to poor OCR confidence.

How it works:

- Fields with confidence < 0.7 get is_low_confidence: true
- Fields with missing confidence (null) get is_low_confidence: true
- Applies to both extracted fields and line items
- Summary statistics show total flagged items count

## 2.2 How to test
Similar to above but we just need to observe specific attributes on response.

✅ Low Confidence Flagging Working:
Fields with confidence >= 0.7 (NOT flagged):
```
{
  "field_name": "vendor_name",
  "value": "High Confidence Corp",
  "confidence": 0.95,
  "is_low_confidence": false  // ← Should be false
}
```

Fields with confidence < 0.7 (Flagged):
```
{
  "field_name": "tax_amount",
  "value": "Low Confidence Amount",
  "confidence": 0.6,
  "is_low_confidence": true   // ← Should be true
}
```

Fields with null confidence (Flagged):
```
{
  "field_name": "notes",
  "value": "No Confidence",
  "confidence": null,
  "is_low_confidence": true   // ← Should be true
}
```

Summary counts should reflect flagged fields:
```

{
  "fields_summary": {
	"total_fields": 5,
	"fields_with_values": 4,
	"flagged_low_confidence_fields": 2  // ← Count of fields with is_low_confidence=true
	}
}
```

Note:
```
Testing thresholds:
0.6 -> True
0.7 -> False
0.8 -> False
None -> True
```

---

# Demo

Video: https://screen.studio/share/ozBqNSJy